### PR TITLE
Making verbose a command line arguent, default is False

### DIFF
--- a/course_documents/assessments/assign_1/code_used_for_marking/mark_castle_visits.py
+++ b/course_documents/assessments/assign_1/code_used_for_marking/mark_castle_visits.py
@@ -124,8 +124,12 @@ def do_testing(verbose = False):
   if verbose:
     print("Total:  " + str(marks) + " of a possible " + str(max_marks))
   return marks
-  
-print(do_testing(verbose = False))
+
+try:
+  verbose = sys.argv[3]
+except IndexError:
+  verbose = False 
+print(do_testing(verbose = verbose))
 
 
 # #  This is example marking code for a typical instance - for some (eg edge or unsatisfiable) instances I test with, not all marks will be available.

--- a/course_documents/assessments/assign_1/code_used_for_marking/mark_colour_ns.py
+++ b/course_documents/assessments/assign_1/code_used_for_marking/mark_colour_ns.py
@@ -98,4 +98,9 @@ def mark_mzn_output(verbose = False):
       print('Total marks for colouring NS: ' + str(marks))
    else:
       print(marks)
-mark_mzn_output(verbose = False)
+      
+try:
+  verbose = sys.argv[1]
+except IndexError:
+  verbose = False 
+mark_mzn_output(verbose = verbose)


### PR DESCRIPTION
Making verbose a command line argument for the marking code, the default value is False.