### PR TITLE
assignment 2: fixed a typo in a comment

### DIFF
--- a/course_documents/assessments/assign_2/cp_assn_2_skeleton_code/submitted_solution.py
+++ b/course_documents/assessments/assign_2/cp_assn_2_skeleton_code/submitted_solution.py
@@ -20,7 +20,7 @@ def run_ilp(instance_graph, start_node = 1, timeout=1000):
 
 
 #
-# This function should run your ILP implementation
+# This function should run your CP implementation
 # for infectious vaccine 
 # - instance_graph will be a networkx graph object
 # - start_node is the node where the fire starts


### PR DESCRIPTION
The documentation for the `run_cp` function said "run your ILP implementation" just like `run_ilp`. Should it not say "run your CP implementation"?
